### PR TITLE
feat(validate) added automatic coercion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ assert(jsonschema.jsonschema_validator(my_schema))
 
 -- Note: do cache the result of schema compilation as this is a quite
 -- expensive process
-local my_validator = jsonschema.generate_validator(my_schema)
+local my_validator = jsonschema.generate_validator(my_schema, options)
 
 -- Now validate some data against our spec:
 local my_data = { foo='hello', bar=42 }
@@ -66,6 +66,40 @@ metatable on array tables. This can be easily achieved by calling
 Besides proper validation of objects and arrays, it is also important for
 performance. Without the meta table, the library will traverse the entire
 table in a non-JITable way.
+
+### Automatic coercion of numbers, integers and booleans
+
+When validating properties that are not json, the input usually always is a
+string value. For example a query string or header value.
+
+For these cases there is an option `coercion`. If you set this flag then
+a string value targetting a type of `boolean`, `number`, or `integer` will be
+attempted coerced to the proper type. After which the validation will occur.
+
+```lua
+local jsonschema = require 'resty.ljsonschema'
+
+local my_schema = {
+  type = 'object',
+  properties = {
+    foo = { type = 'boolean' },
+    bar = { type = 'number' },
+  },
+}
+
+local options = {
+  coercion = true,
+}
+-- Note: do cache the result of schema compilation as this is a quite
+-- expensive process
+local validator          = jsonschema.generate_validator(my_schema)
+local coercing_validator = jsonschema.generate_validator(my_schema, options)
+
+-- Now validate string values against our spec:
+local my_data = { foo='true', bar='42' }
+print(validator(my_data))            -->   false
+print(coercing_validator(my_data))   -->   true
+```
 
 ### Advanced usage
 

--- a/spec/coercion_spec.lua
+++ b/spec/coercion_spec.lua
@@ -1,0 +1,122 @@
+local json = require 'cjson'
+json.decode_array_with_array_mt(true)
+local jsonschema = require 'resty.ljsonschema'
+
+describe("[string coercion]", function()
+
+  describe("number:", function()
+
+    local schema = {
+        type = "number",
+        minimum = 1.1,
+        maximum = 3,
+        exclusiveMinimum = true,
+    }
+
+    it("coerces a number", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = true,
+        }))
+      assert.is_false(validator("1"))
+      assert.is_false(validator("1.1"))
+      assert.is_true(validator("2"))
+      assert.is_true(validator("3"))
+    end)
+
+    it("does not coerce a number if not set to do so", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = false,
+        }))
+      assert.is_false(validator("1"))
+      assert.is_false(validator("1.1"))
+      assert.is_false(validator("2"))
+      assert.is_false(validator("3"))
+    end)
+
+  end)
+
+  describe("integer:", function()
+
+    local schema = {
+        type = "integer",
+        minimum = 1,
+        maximum = 3,
+        exclusiveMinimum = true,
+    }
+
+    it("coerces an integer", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = true,
+        }))
+      assert.is_false(validator("1"))
+      assert.is_true(validator("2"))
+      assert.is_true(validator("3"))
+    end)
+
+    it("does not coerce an integer if not set to do so", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = false,
+        }))
+      assert.is_false(validator("1"))
+      assert.is_false(validator("2"))
+      assert.is_false(validator("3"))
+    end)
+
+  end)
+
+  describe("boolean:", function()
+
+    local schema = {
+        type = "boolean",
+    }
+
+    it("coerces a number", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = true,
+        }))
+      assert.is_false(validator("no boolean"))
+      assert.is_true(validator("true"))
+      assert.is_true(validator("false"))
+    end)
+
+    it("does not coerce a boolean if not set to do so", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = false,
+        }))
+      assert.is_false(validator("no boolean"))
+      assert.is_false(validator("true"))
+      assert.is_false(validator("false"))
+    end)
+
+  end)
+
+  describe("type list (boolean and number)", function()
+
+    local schema = {
+        type = { "number", "boolean"},
+        minimum = 1.1,
+        maximum = 3,
+        exclusiveMinimum = true,
+    }
+
+    it("coerces a number", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          coercion = true,
+        }))
+      assert.is_false(validator("1"))
+      assert.is_false(validator("1.1"))
+      assert.is_true(validator("2"))
+      assert.is_true(validator("3"))
+    end)
+
+  end)
+
+
+end)


### PR DESCRIPTION
Allows to validate numbers/booleans formatted as strings to be
validated as number/integer/boolean. This is useful when validating
headers, query arguments, or path parameters