### PR TITLE
feat(validate) added date, date-time, time format attribute validation

### DIFF
--- a/spec/extra/format/date-time.json
+++ b/spec/extra/format/date-time.json
@@ -1,0 +1,53 @@
+[
+    {
+        "description": "validation of date-time strings",
+        "schema": {"format": "date-time"},
+        "tests": [
+            {
+                "description": "a valid date-time string",
+                "data": "1963-06-19T08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string without second fraction",
+                "data": "1963-06-19T08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with plus offset",
+                "data": "1937-01-01T12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid date-time string with minus offset",
+                "data": "1990-12-31T15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "a invalid day in date-time string",
+                "data": "1990-02-31T15:59:60.123-08:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid offset in date-time string",
+                "data": "1990-12-31T15:59:60-24:00",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "case-insensitive T and Z",
+                "data": "1963-06-19t08:30:06.283185z",
+                "valid": true
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350T01:01:01",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/spec/extra/format/date-time.json
+++ b/spec/extra/format/date-time.json
@@ -34,8 +34,18 @@
                 "valid": false
             },
             {
+                "description": "an invalid time separator in date-time string",
+                "data": "1990-12-31A15:59:60-21:00",
+                "valid": false
+            },
+            {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string where the date and time are valid but string is not r-trimmed",
+                "data": "1963-06-19T08:30:06.283185Z ",
                 "valid": false
             },
             {
@@ -46,6 +56,26 @@
             {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid start sequence",
+                "data": "abc2020-08-07T08:30:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid end sequence",
+                "data": "2020-08-07T08:30:00Zcba",
+                "valid": false
+            },
+            {
+                "description": "invalid start and end sequence",
+                "data": "abc2020-08-07T08:30:00Zcba",
+                "valid": false
+            },
+            {
+                "description": "invalid random garbage data",
+                "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
                 "valid": false
             }
         ]

--- a/spec/extra/format/date.json
+++ b/spec/extra/format/date.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "validation of date strings",
+        "schema": {"format": "date"},
+        "tests": [
+            {
+                "description": "a valid date string",
+                "data": "1963-06-19",
+                "valid": true
+            },
+            {
+                "description": "a valid leap year date",
+                "data": "2020-02-29",
+                "valid": true
+            },
+            {
+                "description": "a invalid leap year date",
+                "data": "2019-02-29",
+                "valid": false
+            },
+            {
+                "description": "a invalid February date",
+                "data": "2019-02-30",
+                "valid": false
+            },
+            {
+                "description": "an invalid date-time string",
+                "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "2013-350",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/spec/extra/format/date.json
+++ b/spec/extra/format/date.json
@@ -24,13 +24,38 @@
                 "valid": false
             },
             {
-                "description": "an invalid date-time string",
+                "description": "an invalid date string",
                 "data": "06/19/1963",
+                "valid": false
+            },
+            {
+                "description": "an invalid date string where the date is valid but string is not r-trimmed",
+                "data": "1963-06-19 ",
                 "valid": false
             },
             {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350",
+                "valid": false
+            },
+            {
+                "description": "invalid start sequence",
+                "data": "abc2020-08-07",
+                "valid": false
+            },
+            {
+                "description": "invalid end sequence",
+                "data": "2020-08-07cba",
+                "valid": false
+            },
+            {
+                "description": "invalid start and end sequence",
+                "data": "abc2020-08-07cba",
+                "valid": false
+            },
+            {
+                "description": "invalid random garbage data",
+                "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
                 "valid": false
             }
         ]

--- a/spec/extra/format/time.json
+++ b/spec/extra/format/time.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "validation of time strings",
+        "schema": {"format": "time"},
+        "tests": [
+            {
+                "description": "a valid time string",
+                "data": "08:30:06.283185Z",
+                "valid": true
+            },
+            {
+                "description": "an invalid time string",
+                "data": "08:30:06 PST",
+                "valid": false
+            },
+            {
+                "description": "only RFC3339 not all of ISO 8601 are valid",
+                "data": "01:01:01,1111",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/spec/extra/format/time.json
+++ b/spec/extra/format/time.json
@@ -9,13 +9,58 @@
                 "valid": true
             },
             {
+                "description": "a valid time string without second fraction",
+                "data": "08:30:06Z",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with plus offset",
+                "data": "12:00:27.87+00:20",
+                "valid": true
+            },
+            {
+                "description": "a valid time string with minus offset",
+                "data": "15:59:50.123-08:00",
+                "valid": true
+            },
+            {
+                "description": "an invalid offset in time string",
+                "data": "15:59:60-24:00",
+                "valid": false
+            },
+            {
                 "description": "an invalid time string",
                 "data": "08:30:06 PST",
                 "valid": false
             },
             {
+                "description": "an invalid time string where the time is valid but string is not r-trimmed",
+                "data": "08:30:06 ",
+                "valid": false
+            },
+            {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "01:01:01,1111",
+                "valid": false
+            },
+            {
+                "description": "invalid start sequence",
+                "data": "abc2020-08-07T08:30:00Z",
+                "valid": false
+            },
+            {
+                "description": "invalid end sequence",
+                "data": "08:30:00Zcba",
+                "valid": false
+            },
+            {
+                "description": "invalid start and end sequence",
+                "data": "abc08:30:00Zcba",
+                "valid": false
+            },
+            {
+                "description": "invalid random garbage data",
+                "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
                 "valid": false
             }
         ]

--- a/spec/extra/format/unknown.json
+++ b/spec/extra/format/unknown.json
@@ -1,0 +1,13 @@
+[
+  {
+      "description": "validation of unknown format attribute",
+      "schema": {"format": "unknown"},
+      "tests": [
+          {
+              "description": "a unknown format attribute should pass thru validator",
+              "data": "doesn't matter what we put here, always valid",
+              "valid": true
+          }
+      ]
+  }
+]

--- a/spec/extra/format/unknown.json
+++ b/spec/extra/format/unknown.json
@@ -9,27 +9,5 @@
               "valid": true
           }
       ]
-  },
-  {
-    "description": "validation of unknown format attribute similar to date",
-    "schema": {"format": "date-unknown"},
-    "tests": [
-        {
-            "description": "a unknown format attribute should pass thru validator",
-            "data": "doesn't matter what we put here, always valid",
-            "valid": true
-        }
-    ]
-  },
-  {
-    "description": "validation of unknown format attribute similar to date-time",
-    "schema": {"format": "unknown-time"},
-    "tests": [
-        {
-            "description": "a unknown format attribute should pass thru validator",
-            "data": "doesn't matter what we put here, always valid",
-            "valid": true
-        }
-    ]
   }
 ]

--- a/spec/extra/format/unknown.json
+++ b/spec/extra/format/unknown.json
@@ -9,5 +9,27 @@
               "valid": true
           }
       ]
+  },
+  {
+    "description": "validation of unknown format attribute similar to date",
+    "schema": {"format": "date-unknown"},
+    "tests": [
+        {
+            "description": "a unknown format attribute should pass thru validator",
+            "data": "doesn't matter what we put here, always valid",
+            "valid": true
+        }
+    ]
+  },
+  {
+    "description": "validation of unknown format attribute similar to date-time",
+    "schema": {"format": "unknown-time"},
+    "tests": [
+        {
+            "description": "a unknown format attribute should pass thru validator",
+            "data": "doesn't matter what we put here, always valid",
+            "valid": true
+        }
+    ]
   }
 ]

--- a/spec/suite_spec.lua
+++ b/spec/suite_spec.lua
@@ -67,6 +67,10 @@ local supported = {
   'spec/JSON-Schema-Test-Suite/tests/draft4/refRemote.json',
   'spec/JSON-Schema-Test-Suite/tests/draft4/definitions.json',
   'spec/extra/ref.json',
+  -- format
+  'spec/extra/format/date.json',
+  'spec/extra/format/date-time.json',
+  'spec/extra/format/time.json',
   -- Lua extensions
   'spec/extra/table.json',
   'spec/extra/function.lua',

--- a/spec/suite_spec.lua
+++ b/spec/suite_spec.lua
@@ -71,6 +71,7 @@ local supported = {
   'spec/extra/format/date.json',
   'spec/extra/format/date-time.json',
   'spec/extra/format/time.json',
+  'spec/extra/format/unknown.json',
   -- Lua extensions
   'spec/extra/table.json',
   'spec/extra/function.lua',

--- a/src/resty/ljsonschema/init.lua
+++ b/src/resty/ljsonschema/init.lua
@@ -714,102 +714,104 @@ generate_validator = function(ctx, schema)
       ctx:stmt(        '  end')
     end
     if schema.format then
-      --[[
+      if schema.format == "date" or schema.format == "date-time" or schema.format == "time" then
+        --[[
           Spec: https://tools.ietf.org/html/rfc3339#section-5.6
                 https://tools.ietf.org/html/rfc3339#section-5.7
 
           Handle 'date' and 'date-time' format attributes
         ]]
-      if schema.format:sub(1, 4) == "date" then
-        local date_pattern = "^(%d%d%d%d)-(%d%d)-(%d%d)(.*)"
-        ctx:stmt(sformat(  '  local year, month, day, date_remaining = %s:match(%q)', ctx:param(1), date_pattern))
-        ctx:stmt(          '  year, month, day = (year and tonumber(year) or -1),')
-        ctx:stmt(          '                     (month and tonumber(month) or -1),')
-        ctx:stmt(          '                     (day and tonumber(day) or -1)')
-        ctx:stmt(          '  local is_date_valid = true')
-        ctx:stmt(          '  if day < 0 or day > 31 or month < 0 or month > 12 or year < 0 then')
-        ctx:stmt(          '    is_date_valid =  false')
-        ctx:stmt(          '  elseif month == 2 then')
-        ctx:stmt(          '    if ((year % 400) == 0 or ((year % 100) ~= 0 and (year % 4) == 0)) then')
-        ctx:stmt(          '      if day > 29 then')
-        ctx:stmt(sformat(  '        return false, %s([[expected valid leap year date, got %%q]], %s)', ctx:libfunc('string.format'), ctx:param(1)))
-        ctx:stmt(          '      end')
-        ctx:stmt(          '    else')
-        ctx:stmt(          '      is_date_valid =  day <= 28')
-        ctx:stmt(          '    end')
-        ctx:stmt(          '  elseif month == 4 or month == 6 or month == 9 or month == 11 then')
-        ctx:stmt(          '    is_date_valid =  day <= 30')
-        ctx:stmt(          '  else')
-        ctx:stmt(          '    is_date_valid =  day <= 31')
-        ctx:stmt(          '  end')
+        if schema.format:sub(1, 4) == "date" then
+          local date_pattern = "^(%d%d%d%d)-(%d%d)-(%d%d)(.*)"
+          ctx:stmt(sformat(  '  local year, month, day, date_remaining = %s:match(%q)', ctx:param(1), date_pattern))
+          ctx:stmt(          '  year, month, day = (year and tonumber(year) or -1),')
+          ctx:stmt(          '                     (month and tonumber(month) or -1),')
+          ctx:stmt(          '                     (day and tonumber(day) or -1)')
+          ctx:stmt(          '  local is_date_valid = true')
+          ctx:stmt(          '  if day < 0 or day > 31 or month < 0 or month > 12 or year < 0 then')
+          ctx:stmt(          '    is_date_valid =  false')
+          ctx:stmt(          '  elseif month == 2 then')
+          ctx:stmt(          '    if ((year % 400) == 0 or ((year % 100) ~= 0 and (year % 4) == 0)) then')
+          ctx:stmt(          '      if day > 29 then')
+          ctx:stmt(sformat(  '        return false, %s([[expected valid leap year date, got %%q]], %s)', ctx:libfunc('string.format'), ctx:param(1)))
+          ctx:stmt(          '      end')
+          ctx:stmt(          '    else')
+          ctx:stmt(          '      is_date_valid =  day <= 28')
+          ctx:stmt(          '    end')
+          ctx:stmt(          '  elseif month == 4 or month == 6 or month == 9 or month == 11 then')
+          ctx:stmt(          '    is_date_valid =  day <= 30')
+          ctx:stmt(          '  else')
+          ctx:stmt(          '    is_date_valid =  day <= 31')
+          ctx:stmt(          '  end')
+
+          --[[
+            Handle invalid date and formats:
+
+            * 'date'      - Ensure the date is valid and their is no remaining
+                            string to process.
+            * 'date-time' - Ensure the date is valid and contains T or t to
+                            continue processing the time format. Update the
+                            remaining string to move based the time attribute
+                            indicator.
+            ]]
+          if schema.format == "date-time" then
+            ctx:stmt(        '  if not is_date_valid or not (date_remaining and string.match(date_remaining:sub(1), "[Tt]")) then')
+          else
+            ctx:stmt(        '  if not is_date_valid or date_remaining ~= "" then')
+          end
+          ctx:stmt(sformat(  '    return false, %s([[expected valid %q, got %%q]], %s)', ctx:libfunc('string.format'), schema.format, ctx:param(1)))
+          if schema.format == "date-time" then
+            ctx:stmt(        '  else')
+            ctx:stmt(        '    date_remaining = date_remaining:sub(2, -1)')
+          end
+          ctx:stmt(          '  end')
+        end
 
         --[[
-          Handle invalid date and formats:
+            Spec: https://tools.ietf.org/html/rfc3339#section-5.6
+                  https://tools.ietf.org/html/rfc3339#section-5.7
 
-          * 'date'      - Ensure the date is valid and their is no remaining
-                          string to process.
-          * 'date-time' - Ensure the date is valid and contains T or t to
-                          continue processing the time format. Update the
-                          remaining string to move based the time attribute
-                          indicator.
+            Handle 'date-time' and 'time' format attributes
           ]]
-        if schema.format == "date-time" then
-          ctx:stmt(        '  if not is_date_valid or not (date_remaining and string.match(date_remaining:sub(1), "[Tt]")) then')
-        else
-          ctx:stmt(        '  if not is_date_valid or date_remaining ~= "" then')
-        end
-        ctx:stmt(sformat(  '    return false, %s([[expected valid %q, got %%q]], %s)', ctx:libfunc('string.format'), schema.format, ctx:param(1)))
-        if schema.format == "date-time" then
-          ctx:stmt(        '  else')
-          ctx:stmt(        '    date_remaining = date_remaining:sub(2, -1)')
-        end
-        ctx:stmt(          '  end')
-      end
+        if schema.format:sub(-4) == "time" then
+          local time_pattern = "(%d%d)%:([0-5]%d)%:([%d%.]+)([Zz%+%-])(.*)"
+          local offset_pattern = "(%d%d)%:([0-5]%d)$"
 
-      --[[
-          Spec: https://tools.ietf.org/html/rfc3339#section-5.6
-                https://tools.ietf.org/html/rfc3339#section-5.7
-
-          Handle 'date-time' and 'time' format attributes
-        ]]
-      if schema.format:sub(-4) == "time" then
-        local time_pattern = "(%d%d)%:([0-5]%d)%:([%d%.]+)([Zz%+%-])(.*)"
-        local offset_pattern = "(%d%d)%:([0-5]%d)$"
-
-        ctx:stmt(            '  local offset_hour, offset_minute')
-        if schema.format == "date-time" then
-          ctx:stmt(sformat(  '  local time_pattern = %q', time_pattern))
-          ctx:stmt(          '  local hour, minute, seconds, sign_offset, time_remaining = date_remaining:match(time_pattern)')
-          ctx:stmt(          '  local last_character = date_remaining:sub(-1)')
-        else
-          ctx:stmt(sformat(  '  local time_pattern = %q', "^" .. time_pattern))
-          ctx:stmt(sformat(  '  local hour, minute, seconds, sign_offset, time_remaining = %s:match(time_pattern)', ctx:param(1)))
-          ctx:stmt(sformat(  '  local last_character = %s:sub(-1)', ctx:param(1)))
+          ctx:stmt(            '  local offset_hour, offset_minute')
+          if schema.format == "date-time" then
+            ctx:stmt(sformat(  '  local time_pattern = %q', time_pattern))
+            ctx:stmt(          '  local hour, minute, seconds, sign_offset, time_remaining = date_remaining:match(time_pattern)')
+            ctx:stmt(          '  local last_character = date_remaining:sub(-1)')
+          else
+            ctx:stmt(sformat(  '  local time_pattern = %q', "^" .. time_pattern))
+            ctx:stmt(sformat(  '  local hour, minute, seconds, sign_offset, time_remaining = %s:match(time_pattern)', ctx:param(1)))
+            ctx:stmt(sformat(  '  local last_character = %s:sub(-1)', ctx:param(1)))
+          end
+          ctx:stmt(            '  if time_remaining then')
+          ctx:stmt(sformat(    '    offset_hour, offset_minute = time_remaining:match(%q)', offset_pattern))
+          ctx:stmt(            '  end')
+          ctx:stmt(            '  hour, minute, seconds, offset_hour, offset_minute = (hour and tonumber(hour) or -1),')
+          ctx:stmt(            '                                                      (minute and tonumber(minute) or -1),')
+          ctx:stmt(            '                                                      (seconds and tonumber(seconds) or -1),')
+          ctx:stmt(            '                                                      (offset_hour and tonumber(offset_hour) or -1),')
+          ctx:stmt(            '                                                      (offset_minute and tonumber(offset_minute) or -1)')
+          ctx:stmt(            '  local is_time_valid = true')
+          ctx:stmt(            '  if hour < 0 or hour > 23 or seconds < 0 or seconds > 60 then')
+          ctx:stmt(            '    is_time_valid = false')
+          ctx:stmt(            '  end')
+          ctx:stmt(            '  if not sign_offset or not sign_offset:match("[Zz%+%-]") then')
+          ctx:stmt(            '    is_time_valid = false')
+          ctx:stmt(            '  elseif sign_offset:match("[%+%-]") then')
+          ctx:stmt(            '    if offset_hour < 0 or offset_hour > 23 then')
+          ctx:stmt(            '      is_time_valid = false')
+          ctx:stmt(            '    end')
+          ctx:stmt(            '  elseif not string.match(last_character:sub(-1), "[Zz]") then')
+          ctx:stmt(            '    is_time_valid = false')
+          ctx:stmt(            '  end')
+          ctx:stmt(            '  if not is_time_valid then')
+          ctx:stmt(sformat(    '    return false, %s([[expected valid %q, got %%q]], %s)', ctx:libfunc('string.format'), schema.format, ctx:param(1)))
+          ctx:stmt(            '  end')
         end
-        ctx:stmt(            '  if time_remaining then')
-        ctx:stmt(sformat(    '    offset_hour, offset_minute = time_remaining:match(%q)', offset_pattern))
-        ctx:stmt(            '  end')
-        ctx:stmt(            '  hour, minute, seconds, offset_hour, offset_minute = (hour and tonumber(hour) or -1),')
-        ctx:stmt(            '                                                      (minute and tonumber(minute) or -1),')
-        ctx:stmt(            '                                                      (seconds and tonumber(seconds) or -1),')
-        ctx:stmt(            '                                                      (offset_hour and tonumber(offset_hour) or -1),')
-        ctx:stmt(            '                                                      (offset_minute and tonumber(offset_minute) or -1)')
-        ctx:stmt(            '  local is_time_valid = true')
-        ctx:stmt(            '  if hour < 0 or hour > 23 or seconds < 0 or seconds > 60 then')
-        ctx:stmt(            '    is_time_valid = false')
-        ctx:stmt(            '  end')
-        ctx:stmt(            '  if not sign_offset or not sign_offset:match("[Zz%+%-]") then')
-        ctx:stmt(            '    is_time_valid = false')
-        ctx:stmt(            '  elseif sign_offset:match("[%+%-]") then')
-        ctx:stmt(            '    if offset_hour < 0 or offset_hour > 23 then')
-        ctx:stmt(            '      is_time_valid = false')
-        ctx:stmt(            '    end')
-        ctx:stmt(            '  elseif not string.match(last_character:sub(-1), "[Zz]") then')
-        ctx:stmt(            '    is_time_valid = false')
-        ctx:stmt(            '  end')
-        ctx:stmt(            '  if not is_time_valid then')
-        ctx:stmt(sformat(    '    return false, %s([[expected valid %q, got %%q]], %s)', ctx:libfunc('string.format'), schema.format, ctx:param(1)))
-        ctx:stmt(            '  end')
       end
     end
     ctx:stmt('end') -- if string


### PR DESCRIPTION
This adds the ability to validate the format attribute within a schema
via a regular expression for `date`, `date-time` and `time`. `date-time`
is the only added attribute in this commit that is listed in Draft 4;
however, the draft indicates custom formats may exist. This added
validation follows the RFC3339 specification section 5.6 and section 5.7
for dates and time.