### PR TITLE
fix(generator) escape format specifier in pattern expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ at this time:
 History
 -------
 
+### 1.0.x (unreleased)
+ - fix: if a `schema.pattern` clause contained a `%` then the generated code
+   for error mesages (invoking `string.format`) would fail because it tried
+   to substitute it (assuming it to be a format specifier). `%` is now properly 
+   escaped.
+
 ### 1.0 (15-may-2020)
 
  - fix: using a string-key containing only numbers would fail because it was

--- a/spec/generator_spec.lua
+++ b/spec/generator_spec.lua
@@ -1394,6 +1394,35 @@ describe("[code generator]", function()
     end)
   end)
 
+  describe("#pattern failure error message can contain % (format specifier)", function()
+    it("single", function()
+      local test_schema = [[{
+        "pattern": "^%$",
+        "type": "string"
+      }]]
+      local func_as_string = jsonschema.generate_validator_code(cjson.decode(test_schema))
+      assert.not_nil(string.find(func_as_string, "\"^%%$\""))
+    end)
+
+    it("repeated", function()
+      local test_schema = [[{
+        "pattern": "^%%%$",
+        "type": "string"
+      }]]
+      local func_as_string = jsonschema.generate_validator_code(cjson.decode(test_schema))
+      assert.not_nil(string.find(func_as_string, "\"^%%%%%%$\""))
+    end)
+
+    it("mixed", function()
+      local test_schema = [[{
+        "pattern": "^1%2%%3%4$",
+        "type": "string"
+      }]]
+      local func_as_string = jsonschema.generate_validator_code(cjson.decode(test_schema))
+      assert.not_nil(string.find(func_as_string, "\"^1%%2%%%%3%%4$\""))
+    end)
+  end)
+
 end)
 
 

--- a/spec/generator_spec.lua
+++ b/spec/generator_spec.lua
@@ -1394,7 +1394,7 @@ describe("[code generator]", function()
     end)
   end)
 
-  describe("#pattern failure error message can contain % (format specifier)", function()
+  describe("pattern failure error message can contain % (format specifier)", function()
     it("single", function()
       local test_schema = [[{
         "pattern": "^%$",

--- a/src/resty/ljsonschema/init.lua
+++ b/src/resty/ljsonschema/init.lua
@@ -706,8 +706,11 @@ generate_validator = function(ctx, schema)
       ctx:stmt(        '  end')
     end
     if schema.pattern then
+      -- Ensure patterns escape format specifiers for error messages
+      local format_escaped_pattern = string.gsub(schema.pattern, "%%", "%%%%")
+
       ctx:stmt(sformat('  if not %s(%s, %q) then', ctx:libfunc('custom.match_pattern'), ctx:param(1), schema.pattern))
-      ctx:stmt(sformat('    return false, %s([[failed to match pattern ]] .. %q .. [[ with %%q]], %s)', ctx:libfunc('string.format'), schema.pattern, ctx:param(1)))
+      ctx:stmt(sformat('    return false, %s([[failed to match pattern ]] .. %q .. [[ with %%q]], %s)', ctx:libfunc('string.format'), format_escaped_pattern, ctx:param(1)))
       ctx:stmt(        '  end')
     end
     ctx:stmt('end') -- if string


### PR DESCRIPTION
If an error occurred during pattern matching where a regex contained a `%` format specifier the error message could fail to generate due to `string.format` attempting to expand based on the pattern.