### PR TITLE
When anyOf validation fails, report subvalidators

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ History
 ### 1.1.x (unreleased)
  - fix: fixes an error in the `maxItems` error message (#7)
  - fix: date-time validation would error out on bad input (#10)
+ - improvement: anyOf failures now list what failed (#9)
 
 ### 1.1.0 (18-aug-2020)
  - fix: if a `schema.pattern` clause contained a `%` then the generated code

--- a/spec/extra/errors/anyOf.json
+++ b/spec/extra/errors/anyOf.json
@@ -1,0 +1,78 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false,
+                "error": "object needs one of the following rectifications: 1) wrong type: expected integer, got number; 2) expected 1.5 to be greater than 2"
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false,
+                "error": "wrong type: expected string, got number"
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false,
+                "error": "object needs one of the following rectifications: 1) string too long, expected at most 2, got 3; 2) string too short, expected at least 4, got 3"
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false,
+                "error": "object needs one of the following rectifications: 1) property bar validation failed: wrong type: expected integer, got string; 2) property foo validation failed: wrong type: expected string, got number"
+            }
+        ]
+    }
+]

--- a/spec/suite_spec.lua
+++ b/spec/suite_spec.lua
@@ -72,6 +72,8 @@ local supported = {
   'spec/extra/format/date-time.json',
   'spec/extra/format/time.json',
   'spec/extra/format/unknown.json',
+  -- errors
+  'spec/extra/errors/anyOf.json',
   -- Lua extensions
   'spec/extra/table.json',
   'spec/extra/function.lua',


### PR DESCRIPTION
Currently we only report that none of the alternatives work. Allowing
for subvalidator output means the user can correct by attempting one of
the suggested responses.