### PR TITLE
Fix date-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ History
 
 ### 1.1.x (unreleased)
  - fix: fixes an error in the `maxItems` error message (#7)
+ - fix: date-time validation would error out on bad input (#10)
 
 ### 1.1.0 (18-aug-2020)
  - fix: if a `schema.pattern` clause contained a `%` then the generated code

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ History
 ### 1.1.x (unreleased)
  - fix: fixes an error in the `maxItems` error message (#7)
  - fix: date-time validation would error out on bad input (#10)
+ - improvement: anyOf failures now list what failed (#9)
 
 ### 1.1.0 (18-aug-2020)
  - fix: if a `schema.pattern` clause contained a `%` then the generated code

--- a/spec/extra/dependencies.json
+++ b/spec/extra/dependencies.json
@@ -26,7 +26,8 @@
             {
                 "description": "missing dependency",
                 "data": {"bar": 2},
-                "valid": false
+                "valid": false,
+                "error": "property foo is required when bar is set"
             },
             {
                 "description": "ignores non-objects",
@@ -64,19 +65,22 @@
             {
                 "description": "wrong type",
                 "data": {"foo": "quux", "bar": 2},
-                "valid": false
+                "valid": false,
+                "error": "failed to validate dependent schema for bar: property foo validation failed: wrong type: expected integer, got string"
             },
             {
                 "description": "wrong type other",
                 "data": {"foo": 2, "bar": "quux"},
-                "valid": false
+                "valid": false,
+                "error": "property bar validation failed: wrong type: expected integer, got string"
             },
             {
                 "description": "wrong type both",
                 "data": {"foo": "quux", "bar": "quux"},
-                "valid": false
+                "valid": false,
+                "error": "property bar validation failed: wrong type: expected integer, got string"
             }
         ]
     }
 
-] 
+]

--- a/spec/extra/empty.json
+++ b/spec/extra/empty.json
@@ -9,9 +9,10 @@
         "valid": true
       },
       {
-        "description": "an empty object is an array - AGAINST SPEC",
+        "description": "an empty object is not an array",
         "data": {},
-        "valid": true
+        "valid": false,
+        "error": "wrong type: expected array, got table"
       },
       {
         "description": "a non-empty array is an array",
@@ -21,7 +22,8 @@
       {
         "description": "a non-empty object is not an array",
         "data": {"answer": 42},
-        "valid": false
+        "valid": false,
+        "error": "wrong type: expected array, got table"
       }
     ]
   },
@@ -30,9 +32,10 @@
     "schema": {"type": "object"},
     "tests": [
       {
-        "description": "an empty array is an object - AGAINST SPEC",
+        "description": "an empty array is not an object",
         "data": [],
-        "valid": true
+        "valid": false,
+        "error": "wrong type: expected object, got table"
       },
       {
         "description": "an empty object is an object",
@@ -42,7 +45,8 @@
       {
         "description": "a non-empty array is not an object",
         "data": ["foo", "bar"],
-        "valid": false
+        "valid": false,
+        "error": "wrong type: expected object, got table"
       },
       {
         "description": "a non-empty object is an object",
@@ -54,21 +58,22 @@
   {
     "description": "confusion with properties",
     "schema": {
-      "properties": { 
+      "properties": {
         "foo": {"type": "integer"}
       },
       "required": ["foo"]
     },
     "tests": [
       {
-        "description": "empty array validates against empty property set",
+        "description": "empty array validates against empty property set - AGAINST SPEC ???",
         "data": [],
-        "valid": false
+        "valid": true
       },
       {
         "description": "empty object validates against empty property set",
         "data": {},
-        "valid": false
+        "valid": false,
+        "error": "property foo is required"
       }
     ]
   }

--- a/spec/extra/errors/anyOf.json
+++ b/spec/extra/errors/anyOf.json
@@ -1,0 +1,78 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false,
+                "error": "object needs one of the following rectifications: 1) wrong type: expected integer, got number; 2) expected 1.5 to be greater than 2"
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false,
+                "error": "wrong type: expected string, got number"
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false,
+                "error": "object needs one of the following rectifications: 1) string too long, expected at most 2, got 3; 2) string too short, expected at least 4, got 3"
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false,
+                "error": "object needs one of the following rectifications: 1) property bar validation failed: wrong type: expected integer, got string; 2) property foo validation failed: wrong type: expected string, got number"
+            }
+        ]
+    }
+]

--- a/spec/extra/format/date-time.json
+++ b/spec/extra/format/date-time.json
@@ -26,27 +26,32 @@
             {
                 "description": "a invalid day in date-time string",
                 "data": "1990-02-31T15:59:60.123-08:00",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"1990-02-31T15:59:60.123-08:00\""
             },
             {
                 "description": "an invalid offset in date-time string",
                 "data": "1990-12-31T15:59:60-24:00",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"1990-12-31T15:59:60-24:00\""
             },
             {
                 "description": "an invalid time separator in date-time string",
                 "data": "1990-12-31A15:59:60-21:00",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"1990-12-31A15:59:60-21:00\""
             },
             {
                 "description": "an invalid date-time string",
                 "data": "06/19/1963 08:30:06 PST",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"06/19/1963 08:30:06 PST\""
             },
             {
                 "description": "an invalid date-time string where the date and time are valid but string is not r-trimmed",
                 "data": "1963-06-19T08:30:06.283185Z ",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"1963-06-19T08:30:06.283185Z \""
             },
             {
                 "description": "case-insensitive T and Z",
@@ -56,37 +61,44 @@
             {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350T01:01:01",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"2013-350T01:01:01\""
             },
             {
                 "description": "invalid start sequence",
                 "data": "abc2020-08-07T08:30:00Z",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"abc2020-08-07T08:30:00Z\""
             },
             {
                 "description": "invalid end sequence",
                 "data": "2020-08-07T08:30:00Zcba",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"2020-08-07T08:30:00Zcba\""
             },
             {
                 "description": "invalid start and end sequence",
                 "data": "abc2020-08-07T08:30:00Zcba",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"abc2020-08-07T08:30:00Zcba\""
             },
             {
                 "description": "invalid random garbage data",
                 "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_\""
             },
             {
                 "description": "a valid time string is invalid as a date-time",
                 "data": "08:30:06.283185Z",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"08:30:06.283185Z\""
             },
             {
                 "description": "a valid date string is invalid as a date-time",
                 "data": "1963-06-19",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date-time\", got \"1963-06-19\""
             }
         ]
     }

--- a/spec/extra/format/date-time.json
+++ b/spec/extra/format/date-time.json
@@ -77,6 +77,16 @@
                 "description": "invalid random garbage data",
                 "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
                 "valid": false
+            },
+            {
+                "description": "a valid time string is invalid as a date-time",
+                "data": "08:30:06.283185Z",
+                "valid": false
+            },
+            {
+                "description": "a valid date string is invalid as a date-time",
+                "data": "1963-06-19",
+                "valid": false
             }
         ]
     }

--- a/spec/extra/format/date.json
+++ b/spec/extra/format/date.json
@@ -16,52 +16,62 @@
             {
                 "description": "a invalid leap year date",
                 "data": "2019-02-29",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"2019-02-29\""
             },
             {
                 "description": "a invalid February date",
                 "data": "2019-02-30",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"2019-02-30\""
             },
             {
                 "description": "an invalid date string",
                 "data": "06/19/1963",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"06/19/1963\""
             },
             {
                 "description": "an invalid date string where the date is valid but string is not r-trimmed",
                 "data": "1963-06-19 ",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"1963-06-19 \""
             },
             {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "2013-350",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"2013-350\""
             },
             {
                 "description": "invalid start sequence",
                 "data": "abc2020-08-07",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"abc2020-08-07\""
             },
             {
                 "description": "invalid end sequence",
                 "data": "2020-08-07cba",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"2020-08-07cba\""
             },
             {
                 "description": "invalid start and end sequence",
                 "data": "abc2020-08-07cba",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"abc2020-08-07cba\""
             },
             {
                 "description": "invalid random garbage data",
                 "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_\""
             },
             {
                 "description": "a valid time string is invalid as a date",
                 "data": "08:30:06.283185Z",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"date\", got \"08:30:06.283185Z\""
             }
         ]
     }

--- a/spec/extra/format/date.json
+++ b/spec/extra/format/date.json
@@ -57,6 +57,11 @@
                 "description": "invalid random garbage data",
                 "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
                 "valid": false
+            },
+            {
+                "description": "a valid time string is invalid as a date",
+                "data": "08:30:06.283185Z",
+                "valid": false
             }
         ]
     }

--- a/spec/extra/format/time.json
+++ b/spec/extra/format/time.json
@@ -26,47 +26,56 @@
             {
                 "description": "an invalid offset in time string",
                 "data": "15:59:60-24:00",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"15:59:60-24:00\""
             },
             {
                 "description": "an invalid time string",
                 "data": "08:30:06 PST",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"08:30:06 PST\""
             },
             {
                 "description": "an invalid time string where the time is valid but string is not r-trimmed",
                 "data": "08:30:06 ",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"08:30:06 \""
             },
             {
                 "description": "only RFC3339 not all of ISO 8601 are valid",
                 "data": "01:01:01,1111",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"01:01:01,1111\""
             },
             {
                 "description": "invalid start sequence",
                 "data": "abc2020-08-07T08:30:00Z",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"abc2020-08-07T08:30:00Z\""
             },
             {
                 "description": "invalid end sequence",
                 "data": "08:30:00Zcba",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"08:30:00Zcba\""
             },
             {
                 "description": "invalid start and end sequence",
                 "data": "abc08:30:00Zcba",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"abc08:30:00Zcba\""
             },
             {
                 "description": "invalid random garbage data",
                 "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_\""
             },
             {
                 "description": "a valid date string is invalid as a time",
                 "data": "1963-06-19",
-                "valid": false
+                "valid": false,
+                "error": "expected valid \"time\", got \"1963-06-19\""
             }
         ]
     }

--- a/spec/extra/format/time.json
+++ b/spec/extra/format/time.json
@@ -62,6 +62,11 @@
                 "description": "invalid random garbage data",
                 "data": "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_",
                 "valid": false
+            },
+            {
+                "description": "a valid date string is invalid as a time",
+                "data": "1963-06-19",
+                "valid": false
             }
         ]
     }

--- a/spec/extra/ref.json
+++ b/spec/extra/ref.json
@@ -16,7 +16,8 @@
             {
                 "description": "mismatch",
                 "data": {"bar": true},
-                "valid": false
+                "valid": false,
+                "error": "property bar validation failed: wrong type: expected integer, got boolean"
             }
         ]
     },
@@ -45,7 +46,8 @@
             {
                 "description": "mismatch array",
                 "data": [1, "foo"],
-                "valid": false
+                "valid": false,
+                "error": "failed to validate item 1: wrong type: expected string, got number"
             }
         ]
     }

--- a/spec/extra/sanity.json
+++ b/spec/extra/sanity.json
@@ -57,12 +57,14 @@
       {
         "description": "correct type but invalid properties is invalid",
         "data": {"foo": "bar"},
-        "valid": false
+        "valid": false,
+        "error": "property foo validation failed: wrong type: expected integer, got string"
       },
       {
         "description": "incorrect type is invalid",
         "data": ["foo", 42],
-        "valid": false
+        "valid": false,
+        "error": "wrong type: expected object, got table"
       }
     ]
   },
@@ -82,9 +84,9 @@
         "valid": true
       },
       {
-        "description": "ignores non-objects (empty array version) - AGAINST SPEC",
+        "description": "ignores non-objects (empty array version) - AGAINST SPEC ???",
         "data": [],
-        "valid": false
+        "valid": true
       }
     ]
   },

--- a/spec/extra/table.json
+++ b/spec/extra/table.json
@@ -26,7 +26,8 @@
             {
                 "description": "number",
                 "data": 42,
-                "valid": false
+                "valid": false,
+                "error": "wrong type: expected table, got number"
             }
         ]
     },
@@ -49,17 +50,20 @@
             {
                 "description": "additional property",
                 "data": { "foo": 42, "bar": false },
-                "valid": false
+                "valid": false,
+                "error": "additional properties forbidden, found bar"
             },
             {
                 "description": "wrong property type",
                 "data": { "foo": "bar" },
-                "valid": false
+                "valid": false,
+                "error": "property foo validation failed: wrong type: expected integer, got string"
             },
             {
                 "description": "missing property",
                 "data": { },
-                "valid": false
+                "valid": false,
+                "error": "property foo is required"
             }
         ]
     }

--- a/spec/suite_spec.lua
+++ b/spec/suite_spec.lua
@@ -72,6 +72,8 @@ local supported = {
   'spec/extra/format/date-time.json',
   'spec/extra/format/time.json',
   'spec/extra/format/unknown.json',
+  -- errors
+  'spec/extra/errors/anyOf.json',
   -- Lua extensions
   'spec/extra/table.json',
   'spec/extra/function.lua',

--- a/spec/suite_spec.lua
+++ b/spec/suite_spec.lua
@@ -28,8 +28,8 @@ end
 
 
 local supported = {
---  'spec/extra/sanity.json',
---  'spec/extra/empty.json',
+  'spec/extra/sanity.json',
+  'spec/extra/empty.json',
   'spec/JSON-Schema-Test-Suite/tests/draft4/type.json',
   -- objects
   'spec/JSON-Schema-Test-Suite/tests/draft4/properties.json',
@@ -139,6 +139,9 @@ describe("[JSON schema Draft 4]", function()
                   assert.has.no.error(function()
                     result, err = validator(case.data)
                   end)
+                  if case.error then
+                    assert.equal(case.error, err)
+                  end
                   assert.has.error(function()
                     assert(result, err)
                   end)

--- a/spec/suite_spec.lua
+++ b/spec/suite_spec.lua
@@ -135,8 +135,12 @@ describe("[JSON schema Draft 4]", function()
                     assert(validator(case.data))
                   end)
                 else
+                  local result, err
+                  assert.has.no.error(function()
+                    result, err = validator(case.data)
+                  end)
                   assert.has.error(function()
-                    assert(validator(case.data))
+                    assert(result, err)
                   end)
                 end
               end) -- it

--- a/src/resty/ljsonschema/init.lua
+++ b/src/resty/ljsonschema/init.lua
@@ -728,7 +728,7 @@ generate_validator = function(ctx, schema)
         local split_pattern = "^(.+)[tT](.+)$"
         ctx:stmt(sformat('  local date_value, time_value = %s:match(%q)', ctx:param(1), split_pattern))
         ctx:stmt(        '  if not date_value then')
-        ctx:stmt(sformat('    return false, %s([[expected valid date-time value, got %%q]], %s)', ctx:libfunc('string.format'), ctx:param(1)))
+        ctx:stmt(sformat('    return false, %s([[expected valid %q, got %%q]], %s)', ctx:libfunc('string.format'), schema.format, ctx:param(1)))
         ctx:stmt(        '  end')
       end
       if schema.format == "date" or schema.format == "date-time" then

--- a/src/resty/ljsonschema/init.lua
+++ b/src/resty/ljsonschema/init.lua
@@ -727,6 +727,9 @@ generate_validator = function(ctx, schema)
       elseif schema.format == "date-time" then
         local split_pattern = "^(.+)[tT](.+)$"
         ctx:stmt(sformat('  local date_value, time_value = %s:match(%q)', ctx:param(1), split_pattern))
+        ctx:stmt(        '  if not date_value then')
+        ctx:stmt(sformat('    return false, %s([[expected valid date-time value, got %%q]], %s)', ctx:libfunc('string.format'), ctx:param(1)))
+        ctx:stmt(        '  end')
       end
       if schema.format == "date" or schema.format == "date-time" then
         local date_pattern = "^(%d%d%d%d)-(%d%d)-(%d%d)$"


### PR DESCRIPTION
If the date-time format wasn't proper it would throw an error instead of returning false. This was hidden in the test suite because the test suite did not distinguish between a failed validation and an error thrown.

- Test suite fixed to distinguish failed validation & errors thrown
- Fixed date-time to no longer throw errors (+ additional tests)
- Added error message validation to the test suite
- re-enabled sanity and empty tests

To review check commit-by-commit