### PR TITLE
fix(id) do not mistake properties called id for an id

### DIFF
--- a/spec/extra/ref.json
+++ b/spec/extra/ref.json
@@ -50,5 +50,28 @@
                 "error": "failed to validate item 1: wrong type: expected string, got number"
             }
         ]
+    },
+    {
+        "description": "a property 'id' on an object named as a keyword ('properties' here)",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "properties": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": { "properties": { "id": "my_id" } },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/src/resty/ljsonschema/store.lua
+++ b/src/resty/ljsonschema/store.lua
@@ -121,7 +121,7 @@ end
 --
 -- * `base`: refers to the base schema (e.g. for a nested subschema to find
 --   its parent schema
--- * `map`: only for "root" schemas, maps indetifiers to subschemas
+-- * `map`: only for "root" schemas, maps indentifiers to subschemas
 function store_mt:ctx(t)
   local c = self.ctx_store[t]
   if not c then
@@ -183,6 +183,11 @@ function store_mt:insert(schema)
 
   local function walk(s, p)
     local id = s.id
+    if type(id) ~= "string" then
+      -- this is not an ID string, but a property called "id", so no need to
+      -- check this one.
+      id = nil
+    end
     if id and s ~= schema and is_schema(p) then
       -- there is an id, but it is not over: we have 2 different cases (!)
       --  1. the id is a fragment: it is some kind of an internal alias
@@ -193,7 +198,7 @@ function store_mt:insert(schema)
         map[id.fragment] = self:ref(s)
       else
         -- relative url (case 2)
-        -- FIXME: I'm sure it's broken bacasue resolution scopes could be
+        -- FIXME: I'm sure it's broken bacause resolution scopes could be
         -- nested... but at the same time, who the hell would do this and it
         -- passes the tests so ¯\_(ツ)_/¯
         local resolved = base_id:resolve(id)
@@ -224,7 +229,7 @@ end
 
 local function new(schema, resolver)
   local self = setmetatable({
-    ctx_store = {}, -- used to store metadata aobut schema parts
+    ctx_store = {}, -- used to store metadata about schema parts
     schemas = {},
     resolver = resolver or default_resolver,
   }, store_mt)


### PR DESCRIPTION
The "is_schema" function checks parents and grandparents by name
so in peculiar cases a property "id" with proper named ancestors
might be mistaken for an "id" reference field. Blame the spec
for not calling it "$id" like the other meta data.