### PR TITLE
fix(schema): allow property name start with underscore for reference schema

### DIFF
--- a/spec/extra/ref.json
+++ b/spec/extra/ref.json
@@ -73,5 +73,28 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "test",
+        "schema": {
+            "properties": {
+                "_bar": {
+                    "$ref": "#/definitions/foo"
+                }
+            },
+            "definitions": {
+               "foo": {
+                  "type": "integer"
+               }
+            },
+            "required": [ "_bar" ]
+        },
+        "tests": [
+            {
+                "description": "ok",
+                "data": { "_bar": 1 },
+                "valid": true
+            }
+        ]
     }
 ]

--- a/src/resty/ljsonschema/store.lua
+++ b/src/resty/ljsonschema/store.lua
@@ -210,12 +210,7 @@ function store_mt:insert(schema)
 
     self:ctx(s).base = schema
     for k, v in pairs(s) do
-      if type(v) == 'table' and
-        (type(k) == 'number' or (
-          k ~= 'enum' and
-          k:sub(1,1) ~= '_'
-        ))
-      then
+      if type(v) == 'table' and (type(k) == 'number' or (k ~= 'enum')) then
         table.insert(p, k)
         walk(v, p)
         table.remove(p)


### PR DESCRIPTION
Summary:

Allow property name starts with an underscore for reference schema