### PR TITLE
fix: avoid numbers being formatted with exponential notation and causing incorrect comparison result

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ For version behaviour and scoping see [Versioning](#versioning).
 - push the commit and the tag; `git push && git push --tags`
 - upload rockspec; `luarocks upload rockspecs/lua-resty-ljsonschema-X.Y.Z-1.rockspec --api-key=abcdef`
 
+### unreleased
+- fix: using default Lua `tostring` on numbers when generating code can loose
+  precision. Implemented a non-lossy function.
+  ([#21](https://github.com/Tieske/lua-resty-ljsonschema/pull/21))
+
 ### 1.1.4 (25-Apr-2023)
 - fix: typo in error message
   ([#16](https://github.com/Tieske/lua-resty-ljsonschema/pull/16))

--- a/spec/coercion_spec.lua
+++ b/spec/coercion_spec.lua
@@ -118,48 +118,4 @@ describe("[string coercion]", function()
 
   end)
 
-  describe("safe integer range", function()
-    it("sanity", function()
-      local min_safe_integer = -9007199254740991
-      local max_safe_integer = 9007199254740991
-
-      local test_schema = {
-        type = 'object',
-        properties = {
-          value= { type = 'integer', minimum = min_safe_integer, maximum = max_safe_integer },
-        },
-      }
-
-      assert(jsonschema.jsonschema_validator(test_schema))
-      local my_validator = jsonschema.generate_validator(test_schema)
-
-      local result, msg = my_validator({ value = min_safe_integer - 1 })
-      assert.is_false(result)
-      assert.equal("property value validation failed: expected -9007199254740992 to be greater than -9007199254740991", msg)
-
-      local result, msg = my_validator({ value = max_safe_integer + 1 })
-      assert.is_false(result)
-      assert.equal("property value validation failed: expected 9007199254740992 to be smaller than 9007199254740991", msg)
-    end)
-
-    it("number", function()
-      local test_schema = {
-        type = 'object',
-        properties = {
-          value= { type = 'number', minimum = -900719925474.12, maximum = 900719925474.12 },
-        },
-      }
-
-      assert(jsonschema.jsonschema_validator(test_schema))
-      local my_validator = jsonschema.generate_validator(test_schema)
-
-      local result, msg = my_validator({ value = -900719925474.123 })
-      assert.is_false(result)
-      assert.equal("property value validation failed: expected -900719925474.123 to be greater than -900719925474.12", msg)
-
-      local result, msg = my_validator({ value = 900719925474.123 })
-      assert.is_false(result)
-      assert.equal("property value validation failed: expected 900719925474.123 to be smaller than 900719925474.12", msg)
-    end)
-  end)
 end)

--- a/spec/coercion_spec.lua
+++ b/spec/coercion_spec.lua
@@ -118,5 +118,48 @@ describe("[string coercion]", function()
 
   end)
 
+  describe("safe integer range", function()
+    it("sanity", function()
+      local min_safe_integer = -9007199254740991
+      local max_safe_integer = 9007199254740991
 
+      local test_schema = {
+        type = 'object',
+        properties = {
+          value= { type = 'integer', minimum = min_safe_integer, maximum = max_safe_integer },
+        },
+      }
+
+      assert(jsonschema.jsonschema_validator(test_schema))
+      local my_validator = jsonschema.generate_validator(test_schema)
+
+      local result, msg = my_validator({ value = min_safe_integer - 1 })
+      assert.is_false(result)
+      assert.equal("property value validation failed: expected -9007199254740992 to be greater than -9007199254740991", msg)
+
+      local result, msg = my_validator({ value = max_safe_integer + 1 })
+      assert.is_false(result)
+      assert.equal("property value validation failed: expected 9007199254740992 to be smaller than 9007199254740991", msg)
+    end)
+
+    it("number", function()
+      local test_schema = {
+        type = 'object',
+        properties = {
+          value= { type = 'number', minimum = -900719925474.12, maximum = 900719925474.12 },
+        },
+      }
+
+      assert(jsonschema.jsonschema_validator(test_schema))
+      local my_validator = jsonschema.generate_validator(test_schema)
+
+      local result, msg = my_validator({ value = -900719925474.123 })
+      assert.is_false(result)
+      assert.equal("property value validation failed: expected -900719925474.123 to be greater than -900719925474.12", msg)
+
+      local result, msg = my_validator({ value = 900719925474.123 })
+      assert.is_false(result)
+      assert.equal("property value validation failed: expected 900719925474.123 to be smaller than 900719925474.12", msg)
+    end)
+  end)
 end)

--- a/spec/number_format_spec.lua
+++ b/spec/number_format_spec.lua
@@ -1,0 +1,59 @@
+local json = require 'cjson'
+json.decode_array_with_array_mt(true)
+local jsonschema = require 'resty.ljsonschema'
+
+describe("[number format, no precision loss]", function()
+
+  it("integer", function()
+    local min_safe_integer = -9007199254740991
+    local max_safe_integer = 9007199254740991
+
+    local test_schema = {
+      type = 'object',
+      properties = {
+        value= { type = 'integer', minimum = min_safe_integer, maximum = max_safe_integer },
+      },
+    }
+
+    assert(jsonschema.jsonschema_validator(test_schema))
+    local my_validator = jsonschema.generate_validator(test_schema)
+
+    assert.same({
+      false, "property value validation failed: expected -9007199254740992 to be greater than -9007199254740991"
+    }, {
+      my_validator({ value = min_safe_integer - 1 })
+    })
+
+    assert.same({
+      false, "property value validation failed: expected 9007199254740992 to be smaller than 9007199254740991"
+    }, {
+      my_validator({ value = max_safe_integer + 1 })
+    })
+  end)
+
+
+  it("float", function()
+    local test_schema = {
+      type = 'object',
+      properties = {
+        value= { type = 'number', minimum = -900719925474.12, maximum = 900719925474.12 },
+      },
+    }
+
+    assert(jsonschema.jsonschema_validator(test_schema))
+    local my_validator = jsonschema.generate_validator(test_schema)
+
+    assert.same({
+      false, "property value validation failed: expected -900719925474.123 to be greater than -900719925474.12"
+    }, {
+      my_validator({ value = -900719925474.123 })
+    })
+
+    assert.same({
+      false, "property value validation failed: expected 900719925474.123 to be smaller than 900719925474.12"
+    }, {
+      my_validator({ value = 900719925474.123 })
+    })
+  end)
+
+end)

--- a/src/resty/ljsonschema/init.lua
+++ b/src/resty/ljsonschema/init.lua
@@ -172,41 +172,6 @@ local function debug_dump(self, code, prefix, err)
   end
 end
 
-local format_number = function(value)
-  if type(value) ~= "number" then
-    return value
-  end
-
-  -- We start at 6 to avoid exponent notation for small numbers, e.g. 10.0 -> 1e+01
-  -- We don't go straight to 17 because it might be ugly, e.g. 3.14 -> 3.1400000000000001
-  -- Be careful with floating point numbers that are also integers.
-  for p = 6, 17 do
-    local s = sformat("%."..p.."g", value)
-    if tonumber(s) == value then
-      return s
-    end
-  end
-  -- 17 digits should have been enough to round trip any non-NaN, non-infinite double.
-  -- See https://stackoverflow.com/a/21162120 and DBL_DECIMAL_DIG in float.h
-  error("impossible")
-end
-
-
-local fn_format_number = [[
-format_number = function(value)
-  if type(value) ~= "number" then
-    return value
-  end
-  for p = 6, 17 do
-    local s = string.format("%."..p.."g", value)
-    if tonumber(s) == value then
-      return s
-    end
-  end
-  error("impossible")
-end
-]]
-
 function codectx_mt:as_func(name, ...)
   local chunk = self:as_string()
   local loaded_chunk, err = load(chunk, 'jsonschema:' .. (name or 'anonymous'))
@@ -330,6 +295,40 @@ function validatorlib.valuekind(v, array_mt, null)
 
   return t
 end
+
+-- The default Lua tostring() function will start using exponential notation
+-- for numbers too early, which means it will be loosing precision. This happens
+-- both floats and ints.
+-- For example:
+--   local x = 9007199254740991
+--   assert(tonumber(tostring(x)) == x))))  -- fails in some cases
+--
+-- We want to avoid that, so we use a custom function that
+-- will try to find a representation that will round trip back to the original.
+--
+-- The "%a" formatter is not used because it is a C99 feature, and it is not
+-- supported by all C compilers (and because it is very ugly).
+--
+-- The original is taken from Pallene: https://github.com/pallene-lang/pallene/blob/b1c0c87b749a3a9e4ebfd500a1a08af53492b8fc/src/pallene/C.lua#L56
+function validatorlib.format_number(value)
+  if type(value) ~= "number" then
+    return value
+  end
+
+  -- We start at 6 to avoid exponent notation for small numbers, e.g. 10.0 -> 1e+01
+  -- We don't go straight to 17 because it might be ugly, e.g. 3.14 -> 3.1400000000000001
+  -- Be careful with floating point numbers that are also integers.
+  for p = 6, 17 do
+    local s = sformat("%."..p.."g", value)
+    if tonumber(s) == value then
+      return s
+    end
+  end
+  -- 17 digits should have been enough to round trip any non-NaN, non-infinite double.
+  -- See https://stackoverflow.com/a/21162120 and DBL_DECIMAL_DIG in float.h
+  error("impossible")
+end
+local format_number = validatorlib.format_number
 
 
 -- used for unique items in arrays (not fast at all)
@@ -863,8 +862,8 @@ generate_validator = function(ctx, schema)
       local op = schema.exclusiveMinimum and '<=' or '<'
       local msg = schema.exclusiveMinimum and 'sctrictly greater' or 'greater'
       ctx:stmt(sformat('  if %s %s %s then', format_number(ctx:param(1)), op, format_number(schema.minimum)))
-      ctx:stmt(sformat('    return false, %s("expected %%s to be %s than %s", format_number(%s))',
-                       ctx:libfunc('string.format'), msg, format_number(schema.minimum), ctx:param(1)))
+      ctx:stmt(sformat('    return false, %s("expected %%s to be %s than %s", %s(%s))',
+                       ctx:libfunc('string.format'), msg, format_number(schema.minimum), ctx:libfunc('lib.format_number'), ctx:param(1)))
       ctx:stmt(        '  end')
     end
 
@@ -872,8 +871,8 @@ generate_validator = function(ctx, schema)
       local op = schema.exclusiveMaximum and '>=' or '>'
       local msg = schema.exclusiveMaximum and 'sctrictly smaller' or 'smaller'
       ctx:stmt(sformat('  if %s %s %s then', format_number(ctx:param(1)), op, format_number(schema.maximum)))
-      ctx:stmt(sformat('    return false, %s("expected %%s to be %s than %s", format_number(%s))',
-                       ctx:libfunc('string.format'), msg, format_number(schema.maximum), ctx:param(1)))
+      ctx:stmt(sformat('    return false, %s("expected %%s to be %s than %s", %s(%s))',
+                       ctx:libfunc('string.format'), msg, format_number(schema.maximum), ctx:libfunc('lib.format_number'), ctx:param(1)))
       ctx:stmt(        '  end')
     end
 
@@ -999,7 +998,6 @@ local function generate_main_validator_ctx(schema, options)
   --    or for dependency injection)
   ctx:preface('local uservalues, lib, custom = ...')
   ctx:preface('local locals = {}')
-  ctx:preface(fn_format_number)
   ctx:stmt('return ', ctx:validator(nil, schema))
   return ctx
 end


### PR DESCRIPTION
The generated function format the number with exponential notation and lost precision, which cause the incorrect comparison result.

```lua
local jsonschema = require 'resty.ljsonschema'

local my_schema = {
  type = 'object',
  properties = {
    value= { type = 'number', minimum = 1, maximum = 9007199254740991 },
  },
}

assert(jsonschema.jsonschema_validator(my_schema))

local my_validator = jsonschema.generate_validator(my_schema)
local my_data = { value = 9007199254740992 }
print(my_validator(my_data)) -- true, which is wrong, as it is greater than the maximum

print(jsonschema.generate_validator_code(my_schema)) -- output the generated validation function
[[
    ...
    if p_1 > 9.007199254741e+15 then  
      return false, string_format("expected %s to be smaller than 9.007199254741e+15", p_1)  
    end  
]]
```

```
> = 9007199254740992 > 9.007199254741e+15   
false -- expect to true
>
```