### PR TITLE
Array validation improvements

### DIFF
--- a/spec/array_detection_spec.lua
+++ b/spec/array_detection_spec.lua
@@ -1,0 +1,67 @@
+local json = require 'cjson'
+json.decode_array_with_array_mt(true)
+local jsonschema = require 'resty.ljsonschema'
+
+describe("[array detection]", function()
+  local schema = {
+      type = "array",
+      elements = "string",
+  }
+
+  describe("default:", function()
+
+    it("requires explicit metatable tagging with cjson.array_mt", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          array_mt = nil,
+        }))
+
+      assert.is_true(validator(setmetatable({}, json.array_mt)))
+      assert.is_true(validator(setmetatable({ "a", "b", "c" }, json.array_mt)))
+      assert.is_false(validator({}))
+      assert.is_false(validator({ "a", "b", "c" }))
+      assert.is_false(validator({ a = 1, b = 2 }))
+      assert.is_false(validator({ "a", "b", "c", a = 1, b = 2 }))
+    end)
+
+  end)
+
+  describe("array_mt == false:", function()
+
+    it("detects arrays via heuristic", function()
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          array_mt = false,
+        }))
+
+      assert.is_true(validator(setmetatable({}, json.array_mt)))
+      assert.is_true(validator(setmetatable({ "a", "b", "c" }, json.array_mt)))
+      assert.is_true(validator({}))
+      assert.is_true(validator({ "a", "b", "c" }))
+      assert.is_false(validator({ a = 1, b = 2 }))
+      assert.is_false(validator({ "a", "b", "c", a = 1, b = 2 }))
+    end)
+
+  end)
+
+  describe("array_mt == <table>:", function()
+
+    it("checks for the custom metatable", function()
+      local array_mt = {}
+
+      local validator = assert(jsonschema.generate_validator(
+        schema, {
+          array_mt = array_mt,
+        }))
+
+      assert.is_true(validator(setmetatable({}, array_mt)))
+      assert.is_true(validator(setmetatable({ "a", "b", "c" }, array_mt)))
+      assert.is_false(validator({}))
+      assert.is_false(validator({ "a", "b", "c" }))
+      assert.is_false(validator({ a = 1, b = 2 }))
+      assert.is_false(validator({ "a", "b", "c", a = 1, b = 2 }))
+    end)
+
+  end)
+
+end)

--- a/src/resty/ljsonschema/init.lua
+++ b/src/resty/ljsonschema/init.lua
@@ -1004,9 +1004,13 @@ end
 
 local _M = {
   generate_validator = function(schema, custom)
+    local array_mt = default_array_mt
+    if custom and custom.array_mt ~= nil then
+      array_mt = custom.array_mt
+    end
     local customlib = {
       null = custom and custom.null or default_null,
-      array_mt = custom and custom.array_mt or default_array_mt,
+      array_mt = array_mt,
       match_pattern = custom and custom.match_pattern or default_match_pattern
     }
     local name = custom and custom.name


### PR DESCRIPTION
1. Fix `custom.array_mt == false` not functioning according to documentation
2. Use luajit `table.nkeys` and `table.isarray` functions in `tablekind_slow()` if available.