### PR TITLE
fix(deps): add lua-cjson dependecy back

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -45,9 +45,7 @@ jobs:
     - uses: leafo/gh-actions-luarocks@v4
 
     - name: dependencies
-      run: |
-        make dev
-        luarocks install lua-cjson
+      run: make dev
 
     - name: test
       run: busted --lua=lua --Xoutput "--color"

--- a/.github/workflows/openresty.yml
+++ b/.github/workflows/openresty.yml
@@ -44,9 +44,7 @@ jobs:
         withLuaPath: "/usr/local/openresty/luajit/"
 
     - name: dependencies
-      run: |
-        make dev
-        luarocks install lua-cjson
+      run: make dev
 
     - name: test
       run: busted

--- a/lua-resty-ljsonschema-scm-1.rockspec
+++ b/lua-resty-ljsonschema-scm-1.rockspec
@@ -28,7 +28,7 @@ description = {
 dependencies = {
    "lua >= 5.1",
    "net-url",
-   -- "lua-cjson", disabled, see https://github.com/openresty/lua-cjson/issues/96
+   "lua-cjson",
 }
 
 build = {


### PR DESCRIPTION
Only merge this after the rockspecs for `lua-cjson` have been fixed. See: https://github.com/openresty/lua-cjson/issues/96